### PR TITLE
build: keeping dependencies in sync with pysherlock. grpcio 1.68.0 breaks py…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
         python_requires=">=3.10",
-        install_requires=["grpcio~=1.17", "protobuf>=3.19,<6"],
+        install_requires=["grpcio~=1.17, <1.68.0", "protobuf>=3.19,<6"],
         package_dir = {"": "src"},
         packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={


### PR DESCRIPTION
Updating grpcio requirement

Before this gets approved make sure to:
[] Update the version file
[] Test proto file compilation
[] Ensure that the server and client code that uses the generated code from these files work